### PR TITLE
Auth middleware

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,12 +4,10 @@
     "": {
       "name": "tuna-reportes-api",
       "dependencies": {
-        "@types/jsonwebtoken": "^9.0.10",
         "dotenv": "^16.5.0",
         "drizzle-orm": "^0.43.1",
         "drizzle-zod": "^0.8.2",
         "hono": "^4.7.5",
-        "jsonwebtoken": "^9.0.2",
         "postgres": "^3.4.7",
         "zod": "^3.25.20",
       },
@@ -118,10 +116,6 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
-
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
-
     "@types/node": ["@types/node@22.14.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -145,8 +139,6 @@
     "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
-    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -183,8 +175,6 @@
     "drizzle-orm": ["drizzle-orm@0.43.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-dUcDaZtE/zN4RV/xqGrVSMpnEczxd5cIaoDeor7Zst9wOe/HzC/7eAaulywWGYXdDEc9oBPMjayVEDg0ziTLJA=="],
 
     "drizzle-zod": ["drizzle-zod@0.8.2", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "zod": "^3.25.1" } }, "sha512-9Do/16OjFFNrQDZgvMtxtDDwKWbFOxUAIwNPKX98SfxrP8H18vhN1BvNXbhelLcdgCE7GEaXDJqBjMExSkhpkA=="],
-
-    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
 
@@ -280,12 +270,6 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
-    "jsonwebtoken": ["jsonwebtoken@9.0.2", "", { "dependencies": { "jws": "^3.2.2", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ=="],
-
-    "jwa": ["jwa@1.4.2", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw=="],
-
-    "jws": ["jws@3.2.2", "", { "dependencies": { "jwa": "^1.4.1", "safe-buffer": "^5.0.1" } }, "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA=="],
-
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
@@ -298,21 +282,7 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
-
-    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
-
-    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
-
-    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
-
-    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
-
-    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
-
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
-
-    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
@@ -365,10 +335,6 @@
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
-
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/package.json
+++ b/package.json
@@ -14,12 +14,10 @@
     "db:studio": "npx drizzle-kit studio"
   },
   "dependencies": {
-    "@types/jsonwebtoken": "^9.0.10",
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.43.1",
     "drizzle-zod": "^0.8.2",
     "hono": "^4.7.5",
-    "jsonwebtoken": "^9.0.2",
     "postgres": "^3.4.7",
     "zod": "^3.25.20"
   },

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -161,7 +161,7 @@ export async function postLoginController(c: Context) {
         userId: user.id,
         email: user.email,
         role: user.role,
-        exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24, // 1 día
+        exp: Math.floor(Date.now() / 1000) + 3600 * 24, // 1 day
       };
       const token = await sign(payload, process.env.JWT_SECRET!);
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import type { Context } from "hono";
-import jwt from "jsonwebtoken";
+import { sign } from "hono/jwt";
 import { z } from "zod/v4";
 import { ERROR_CODES } from "../constants/error-codes";
 import { db, dbSchema } from "../db";
@@ -157,15 +157,14 @@ export async function postLoginController(c: Context) {
     );
 
     if (passwordMatch) {
-      const token = jwt.sign(
-        {
-          userId: user.id,
-          email: user.email,
-          role: user.role,
-        },
-        process.env.JWT_SECRET!,
-        { expiresIn: "1d" },
-      );
+      const payload = {
+        userId: user.id,
+        email: user.email,
+        role: user.role,
+        exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24, // 1 día
+      };
+      const token = await sign(payload, process.env.JWT_SECRET!);
+
       return c.json(
         {
           token,

--- a/src/controllers/events.controller.ts
+++ b/src/controllers/events.controller.ts
@@ -10,6 +10,7 @@ import {
 } from "../schemas/events.schema";
 import type { ErrorResponse } from "../types/error";
 import type { EventPostResponse, EventsGetResponse } from "../types/event";
+import type { AuthUserPayload } from "../types/auth";
 
 export async function getEventsController(c: Context) {
   try {
@@ -94,7 +95,7 @@ export async function createEventController(c: Context) {
     return c.json(errorResponse, 400);
   }
 
-  const user = c.get("user");
+  const user = c.get("user") as AuthUserPayload;
 
   try {
     const insertData = {
@@ -172,7 +173,7 @@ export async function updateEventController(c: Context) {
     );
   }
 
-  const user = c.get("user");
+  const user = c.get("user") as AuthUserPayload;
 
   try {
     const updateData = {

--- a/src/controllers/events.controller.ts
+++ b/src/controllers/events.controller.ts
@@ -94,10 +94,17 @@ export async function createEventController(c: Context) {
     return c.json(errorResponse, 400);
   }
 
+  const user = c.get("user");
+
   try {
+    const insertData = {
+      ...result.data,
+      createdBy: user.userId,
+    };
+
     const [inserted] = await db
       .insert(dbSchema.events)
-      .values(result.data)
+      .values(insertData)
       .returning({ id: dbSchema.events.id });
 
     if (!inserted || !inserted.id) {
@@ -165,10 +172,13 @@ export async function updateEventController(c: Context) {
     );
   }
 
+  const user = c.get("user");
+
   try {
     const updateData = {
       ...result.data,
       updatedAt: new Date().toISOString(),
+      updatedBy: user.userId,
     };
     const [updatedEvent] = await db
       .update(dbSchema.events)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+if (!process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET environment variable is not set.");
+}
+
 import app from "./app";
 
 Bun.serve({

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,0 +1,34 @@
+import type { Context, Next } from "hono";
+import type { ErrorResponse } from "../types/error";
+import { ERROR_CODES } from "../constants/error-codes";
+import { verify } from "hono/jwt";
+
+export async function authMiddleware(c: Context, next: Next) {
+  const authHeader = c.req.header("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message: "Missing or invalid Authorization header",
+        code: ERROR_CODES.VALIDATION,
+      },
+    };
+    return c.json(errorResponse, 401);
+  }
+
+  const token = authHeader.replace("Bearer ", "");
+
+  try {
+    const payload = await verify(token, process.env.JWT_SECRET!);
+    c.set("user", payload);
+    await next();
+  } catch (error) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message:
+          error instanceof Error ? error.message : "Invalid or expired token",
+        code: ERROR_CODES.VALIDATION,
+      },
+    };
+    return c.json(errorResponse, 401);
+  }
+}

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -24,8 +24,7 @@ export async function authMiddleware(c: Context, next: Next) {
   } catch (error) {
     const errorResponse: ErrorResponse = {
       error: {
-        message:
-          error instanceof Error ? error.message : "Invalid or expired token",
+        message: "Invalid or expired token",
         code: ERROR_CODES.VALIDATION,
       },
     };

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,7 +1,10 @@
+import { eq } from "drizzle-orm";
 import type { Context, Next } from "hono";
-import type { ErrorResponse } from "../types/error";
-import { ERROR_CODES } from "../constants/error-codes";
 import { verify } from "hono/jwt";
+import { ERROR_CODES } from "../constants/error-codes";
+import { db, dbSchema } from "../db";
+import type { AuthUserPayload } from "../types/auth";
+import type { ErrorResponse } from "../types/error";
 
 export async function authMiddleware(c: Context, next: Next) {
   const authHeader = c.req.header("Authorization");
@@ -18,7 +21,27 @@ export async function authMiddleware(c: Context, next: Next) {
   const token = authHeader.replace("Bearer ", "");
 
   try {
-    const payload = await verify(token, process.env.JWT_SECRET!);
+    const payload = (await verify(
+      token,
+      process.env.JWT_SECRET!,
+    )) as AuthUserPayload;
+
+    const [user] = await db
+      .select()
+      .from(dbSchema.users)
+      .where(eq(dbSchema.users.id, payload.userId));
+
+    if (!user) {
+      const errorResponse: ErrorResponse = {
+        error: {
+          message: "User not found",
+          code: ERROR_CODES.UNAUTHORIZED,
+        },
+      };
+
+      return c.json(errorResponse, 401);
+    }
+
     c.set("user", payload);
     await next();
   } catch (error) {

--- a/src/routers/events.router.ts
+++ b/src/routers/events.router.ts
@@ -5,12 +5,13 @@ import {
   getEventsController,
   updateEventController,
 } from "../controllers/events.controller";
+import { authMiddleware } from "../middlewares/auth.middleware";
 
 const eventsRouter = new Hono();
 
-eventsRouter.get("/:id", getEventController);
-eventsRouter.get("/", getEventsController);
-eventsRouter.post("/", createEventController);
-eventsRouter.patch("/:id", updateEventController);
+eventsRouter.get("/:id", authMiddleware, getEventController);
+eventsRouter.get("/", authMiddleware, getEventsController);
+eventsRouter.post("/", authMiddleware, createEventController);
+eventsRouter.patch("/:id", authMiddleware, updateEventController);
 
 export default eventsRouter;

--- a/src/tests/events.router.test.ts
+++ b/src/tests/events.router.test.ts
@@ -49,7 +49,6 @@ beforeEach(async () => {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(mockUser),
   });

--- a/src/tests/events.router.test.ts
+++ b/src/tests/events.router.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import app from "../app";
 import { ERROR_CODES } from "../constants/error-codes";
 import { db, dbSchema } from "../db";
+import type { AuthLoginPostResponse } from "../types/auth";
 import type { ErrorResponse } from "../types/error";
 import type {
   Event,
@@ -16,8 +17,51 @@ const mockRequest = {
   type: "festival",
 };
 
+const vinculationCode = "5121caa3-3682-4381-8b97-2ccba11af93c";
+const mockUser = {
+  email: "user@email.com",
+  password: "password",
+};
+
+let token: string;
+
 beforeEach(async () => {
+  await db.insert(dbSchema.members).values({
+    rank: "tuno",
+    birthDate: "2000-01-01",
+    nickname: "testnick",
+    fullName: "Test User",
+    vinculationCode,
+  });
+
+  await app.request("/auth/register", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      ...mockUser,
+      vinculationCode,
+    }),
+  });
+
+  const loginResponse = await app.request("/auth/login", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(mockUser),
+  });
+
+  const loginData = (await loginResponse.json()) as AuthLoginPostResponse;
+  token = loginData.token;
+});
+
+afterEach(async () => {
   await db.delete(dbSchema.events);
+  await db.delete(dbSchema.users);
+  await db.delete(dbSchema.members);
 });
 
 function testMissingField(
@@ -32,7 +76,10 @@ function testMissingField(
       const { [field]: _, ...invalidRequest } = mockRequest;
       response = await app.request("/events", {
         method: "POST",
-        headers: { "Content-type": "application/json" },
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(invalidRequest),
       });
       data = (await response.json()) as ErrorResponse;
@@ -64,6 +111,7 @@ describe("POST /events", () => {
         method: "POST",
         headers: {
           "Content-type": "application/json",
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(mockRequest),
       });
@@ -113,7 +161,11 @@ describe("POST /events", () => {
 describe("GET /events", () => {
   describe("when there are no events", () => {
     it("should return 200 OK and an empty events array", async () => {
-      const response = await app.request("/events");
+      const response = await app.request("/events", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       const data = (await response.json()) as EventsGetResponse;
       expect(response.status).toBe(200);
       expect(data.events).toBeArray();
@@ -130,11 +182,18 @@ describe("GET /events", () => {
     beforeEach(async () => {
       await app.request("/events", {
         method: "POST",
-        headers: { "Content-type": "application/json" },
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(mockRequest),
       });
 
-      response = await app.request("/events");
+      response = await app.request("/events", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       data = (await response.json()) as EventsGetResponse;
       event = data.events.at(0)!;
     });
@@ -164,11 +223,18 @@ describe("GET /events/:id", () => {
     beforeEach(async () => {
       const postResponse = await app.request("/events", {
         method: "POST",
-        headers: { "Content-type": "application/json" },
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(mockRequest),
       });
       const postData = (await postResponse.json()) as EventPostResponse;
-      const getResponse = await app.request("/events");
+      const getResponse = await app.request("/events", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       const getData = (await getResponse.json()) as EventsGetResponse;
       const foundEvent = getData.events.find(
         (event) => event.id === postData.id,
@@ -179,7 +245,11 @@ describe("GET /events/:id", () => {
       }
       createdEvent = foundEvent;
 
-      response = await app.request(`/events/${createdEvent.id}`);
+      response = await app.request(`/events/${createdEvent.id}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       event = (await response.json()) as Event;
     });
 
@@ -193,7 +263,11 @@ describe("GET /events/:id", () => {
   });
   describe("when the id is not an uuid", () => {
     it("should respond with 400 Bad Request", async () => {
-      const response = await app.request("/events/bad-formated-id");
+      const response = await app.request("/events/bad-formated-id", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       expect(response.status).toBe(400);
 
       const data = (await response.json()) as ErrorResponse;
@@ -204,6 +278,11 @@ describe("GET /events/:id", () => {
     it("should respond with 404 Not Found", async () => {
       const response = await app.request(
         "/events/38bd666b-cf64-41d8-8d79-ffffffffffff",
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
       );
       expect(response.status).toBe(404);
 
@@ -221,14 +300,20 @@ describe("PATCH /events/:id", () => {
     beforeEach(async () => {
       const postResponse = await app.request("/events", {
         method: "POST",
-        headers: { "Content-type": "application/json" },
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(mockRequest),
       });
       const postData = (await postResponse.json()) as EventPostResponse;
 
       patchResponse = await app.request(`/events/${postData.id}`, {
         method: "PATCH",
-        headers: { "Content-type": "application/json" },
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           name: "Certamen 26 años",
           date: "2025-09-20T13:00:00.000Z",

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -11,3 +11,10 @@ export type AuthLoginPostResponse = {
     role: string;
   };
 };
+
+export type AuthUserPayload = {
+  userId: string;
+  email: string;
+  role: string;
+  exp: number;
+};


### PR DESCRIPTION
## Add JWT Auth Middleware and Audit Fields to Events

### Summary

This PR introduces JWT-based authentication middleware using Hono’s built-in helpers and applies it to all event routes. It also adds audit fields (`createdBy`, `updatedBy`) to events, associating them with the authenticated user.

---

### Key Changes

- **JWT Middleware**
  - Created a reusable `authMiddleware` using Hono’s `verify` helper to protect routes.
  - Middleware extracts the user from the JWT and attaches it to the request context.

- **Route Protection**
  - Applied the middleware to all `/events` routes (`GET`, `POST`, `PATCH`), requiring authentication for all event operations.

- **Audit Fields**
  - On event creation, the `createdBy` field is set to the authenticated user’s ID.
  - On event update, the `updatedBy` field is set to the authenticated user’s ID.

- **Refactor**
  - Removed the `jsonwebtoken` dependency in favor of Hono’s native JWT helpers.
  
  ---
  
### How to Test

- All `/events` endpoints now require a valid JWT in the `Authorization` header.
Example: `Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...`
- Creating or updating an event will automatically associate the action with the authenticated user.
