### PR TITLE
Members

### DIFF
--- a/drizzle/0003_lumpy_hydra.sql
+++ b/drizzle/0003_lumpy_hydra.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ALTER COLUMN "password_hash" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "members" ADD COLUMN "is_active" boolean DEFAULT true NOT NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,560 @@
+{
+  "id": "a094afb5-e409-4c68-854d-4f6b8851b63b",
+  "prevId": "067933f7-a614-420a-8691-b6935317cf0a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attendances": {
+      "name": "attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'por_confirmar'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendances_event_id_fkey": {
+          "name": "attendances_event_id_fkey",
+          "tableFrom": "attendances",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendances_member_id_fkey": {
+          "name": "attendances_member_id_fkey",
+          "tableFrom": "attendances",
+          "tableTo": "members",
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendances_updated_by_fkey": {
+          "name": "attendances_updated_by_fkey",
+          "tableFrom": "attendances",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendances_event_id_member_id_key": {
+          "name": "attendances_event_id_member_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["event_id", "member_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_international": {
+          "name": "is_international",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'por_confirmar'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_created_by_fkey": {
+          "name": "events_created_by_fkey",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_updated_by_fkey": {
+          "name": "events_updated_by_fkey",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "raul": {
+          "name": "raul",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "member_rank",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_issued_at": {
+          "name": "document_issued_at",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eps": {
+          "name": "eps",
+          "type": "eps_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_type": {
+          "name": "blood_type",
+          "type": "blood_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civil_status": {
+          "name": "civil_status",
+          "type": "civil_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_name": {
+          "name": "partner_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "children_names": {
+          "name": "children_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beca_date": {
+          "name": "beca_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deceased_at": {
+          "name": "deceased_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vinculation_code": {
+          "name": "vinculation_code",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_raul_key": {
+          "name": "members_raul_key",
+          "nullsNotDistinct": false,
+          "columns": ["raul"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_member_id_fkey1": {
+          "name": "users_member_id_fkey1",
+          "tableFrom": "users",
+          "tableTo": "members",
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_member_id_unique": {
+          "name": "users_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["member_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": ["asiste", "no_asiste", "por_confirmar", "no_responde"]
+    },
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": ["local", "google", "clerk"]
+    },
+    "public.blood_type": {
+      "name": "blood_type",
+      "schema": "public",
+      "values": ["a+", "a-", "b+", "b-", "ab+", "ab-", "o+", "o-"]
+    },
+    "public.civil_status": {
+      "name": "civil_status",
+      "schema": "public",
+      "values": ["soltero", "casado", "divorciado"]
+    },
+    "public.eps_provider": {
+      "name": "eps_provider",
+      "schema": "public",
+      "values": [
+        "aliansalud",
+        "colmedica",
+        "compensar",
+        "sanitas",
+        "sura",
+        "salud_total",
+        "colpatria",
+        "coomeva",
+        "famisanar",
+        "medifiatc",
+        "cafesalud",
+        "susalud",
+        "asmetsalud",
+        "nueva_eps",
+        "sanidad_militar",
+        "sisben"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": ["por_confirmar", "confirmado", "realizado", "cancelado"]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "serenata",
+        "ensayo",
+        "festival",
+        "certamen",
+        "remate",
+        "parche",
+        "viaje"
+      ]
+    },
+    "public.member_rank": {
+      "name": "member_rank",
+      "schema": "public",
+      "values": ["aspirante", "bulto", "tuno"]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "editor", "viewer"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1749483602920,
       "tag": "0002_strange_dark_phoenix",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1751759948293,
+      "tag": "0003_lumpy_hydra",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -2,11 +2,13 @@ import { Hono } from "hono";
 import pingRouter from "../routers/ping.router";
 import eventsRouter from "../routers/events.router";
 import authRouter from "../routers/auth.router";
+import membersRouter from "../routers/members.router";
 
 const app = new Hono();
 
 app.route("/ping", pingRouter);
 app.route("/events", eventsRouter);
+app.route("/members", membersRouter);
 app.route("/auth", authRouter);
 
 export default app;

--- a/src/controllers/members.controller.ts
+++ b/src/controllers/members.controller.ts
@@ -1,10 +1,18 @@
 import type { Context } from "hono";
 import { db, dbSchema } from "../db";
-import type { MemberPostResponse, MembersGetResponse } from "../types/member";
+import type {
+  MemberDeleteResponse,
+  MemberPatchResponse,
+  MemberPostResponse,
+  MembersGetResponse,
+} from "../types/member";
 import type { ErrorResponse } from "../types/error";
 import { ERROR_CODES } from "../constants/error-codes";
 import { eq } from "drizzle-orm";
-import { memberInsertSchema } from "../schemas/members.schema";
+import {
+  memberInsertSchema,
+  memberUpdateSchema,
+} from "../schemas/members.schema";
 import { z } from "zod/v4";
 
 export async function getMembersController(c: Context) {
@@ -92,6 +100,99 @@ export async function postMemberController(c: Context) {
       message: "Member created",
     };
     return c.json(response, 201);
+  } catch (error) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message:
+          error instanceof Error ? error.message : "Internal server error",
+        code: ERROR_CODES.INTERNAL,
+      },
+    };
+    return c.json(errorResponse, 500);
+  }
+}
+
+export async function patchMemberController(c: Context) {
+  const id = c.req.param("id");
+  const body = await c.req.json();
+  const result = memberUpdateSchema.safeParse(body);
+
+  if (!result.success) {
+    const tree = z.treeifyError(result.error);
+    const flatErrors = Object.fromEntries(
+      Object.entries(tree.properties ?? {}).map(([key, value]) => [
+        key,
+        value.errors,
+      ]),
+    );
+    const errorResponse: ErrorResponse = {
+      error: {
+        message: "Validation failed",
+        details: flatErrors,
+        code: ERROR_CODES.VALIDATION,
+      },
+    };
+    return c.json(errorResponse, 400);
+  }
+
+  try {
+    const [updated] = await db
+      .update(dbSchema.members)
+      .set(result.data)
+      .where(eq(dbSchema.members.id, id))
+      .returning();
+
+    if (!updated) {
+      const errorResponse: ErrorResponse = {
+        error: {
+          message: "Member not found",
+          code: ERROR_CODES.NOT_FOUND,
+        },
+      };
+      return c.json(errorResponse, 404);
+    }
+
+    const response: MemberPatchResponse = {
+      id: updated.id,
+      message: "Member updated",
+    };
+    return c.json(response, 200);
+  } catch (error) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message:
+          error instanceof Error ? error.message : "Internal server error",
+        code: ERROR_CODES.INTERNAL,
+      },
+    };
+    return c.json(errorResponse, 500);
+  }
+}
+export async function deleteMemberController(c: Context) {
+  const id = c.req.param("id");
+
+  try {
+    const [updated] = await db
+      .update(dbSchema.members)
+      .set({ isActive: false })
+      .where(eq(dbSchema.members.id, id))
+      .returning();
+
+    if (!updated) {
+      const errorResponse: ErrorResponse = {
+        error: {
+          message: "Member not found",
+          code: ERROR_CODES.NOT_FOUND,
+        },
+      };
+      return c.json(errorResponse, 404);
+    }
+
+    const response: MemberDeleteResponse = {
+      id: updated.id,
+      message: "Member deactivated",
+    };
+    return c.json(response, 200);
   } catch (error) {
     const errorResponse: ErrorResponse = {
       error: {

--- a/src/controllers/members.controller.ts
+++ b/src/controllers/members.controller.ts
@@ -1,0 +1,105 @@
+import type { Context } from "hono";
+import { db, dbSchema } from "../db";
+import type { MemberPostResponse, MembersGetResponse } from "../types/member";
+import type { ErrorResponse } from "../types/error";
+import { ERROR_CODES } from "../constants/error-codes";
+import { eq } from "drizzle-orm";
+import { memberInsertSchema } from "../schemas/members.schema";
+import { z } from "zod/v4";
+
+export async function getMembersController(c: Context) {
+  try {
+    const members = await db.select().from(dbSchema.members);
+    const response: MembersGetResponse = {
+      members,
+      count: members.length,
+    };
+    return c.json(response, 200);
+  } catch (error) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message:
+          error instanceof Error ? error.message : "Internal server error",
+        code: ERROR_CODES.INTERNAL,
+      },
+    };
+    return c.json(errorResponse, 500);
+  }
+}
+
+export async function getMemberController(c: Context) {
+  const id = c.req.param("id");
+
+  const [member] = await db
+    .select()
+    .from(dbSchema.members)
+    .where(eq(dbSchema.members.id, id));
+
+  if (!member) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message: "Member not found",
+        code: ERROR_CODES.NOT_FOUND,
+      },
+    };
+    return c.json(errorResponse, 404);
+  }
+  return c.json(member, 200);
+}
+
+export async function postMemberController(c: Context) {
+  const body = await c.req.json();
+  const result = memberInsertSchema.safeParse(body);
+
+  if (!result.success) {
+    const tree = z.treeifyError(result.error);
+
+    const flatErrors = Object.fromEntries(
+      Object.entries(tree.properties ?? {}).map(([key, value]) => [
+        key,
+        value.errors,
+      ]),
+    );
+
+    const errorResponse: ErrorResponse = {
+      error: {
+        message: "Validation failed",
+        details: flatErrors,
+        code: ERROR_CODES.VALIDATION,
+      },
+    };
+    return c.json(errorResponse, 400);
+  }
+
+  try {
+    const [inserted] = await db
+      .insert(dbSchema.members)
+      .values(result.data)
+      .returning({ id: dbSchema.members.id });
+
+    if (!inserted || !inserted.id) {
+      const errorResponse: ErrorResponse = {
+        error: {
+          message: "Failed to create member",
+          code: ERROR_CODES.INTERNAL,
+        },
+      };
+      return c.json(errorResponse, 500);
+    }
+
+    const response: MemberPostResponse = {
+      id: inserted.id,
+      message: "Member created",
+    };
+    return c.json(response, 201);
+  } catch (error) {
+    const errorResponse: ErrorResponse = {
+      error: {
+        message:
+          error instanceof Error ? error.message : "Internal server error",
+        code: ERROR_CODES.INTERNAL,
+      },
+    };
+    return c.json(errorResponse, 500);
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -130,6 +130,7 @@ export const members = pgTable(
     joinedAt: date("joined_at"),
     becaDate: date("beca_date"),
     deceasedAt: date("deceased_at"),
+    isActive: boolean("is_active").default(true).notNull(),
     imageUrl: text("image_url"),
     vinculationCode: uuid("vinculation_code").defaultRandom().notNull(),
     createdAt: timestamp("created_at", {

--- a/src/routers/members.router.ts
+++ b/src/routers/members.router.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import { authMiddleware } from "../middlewares/auth.middleware";
+import {
+  getMemberController,
+  getMembersController,
+  postMemberController,
+} from "../controllers/members.controller";
+
+const membersRouter = new Hono();
+
+membersRouter.get("/", authMiddleware, getMembersController);
+membersRouter.get("/:id", authMiddleware, getMemberController);
+membersRouter.post("/", authMiddleware, postMemberController);
+
+export default membersRouter;

--- a/src/routers/members.router.ts
+++ b/src/routers/members.router.ts
@@ -1,8 +1,10 @@
 import { Hono } from "hono";
 import { authMiddleware } from "../middlewares/auth.middleware";
 import {
+  deleteMemberController,
   getMemberController,
   getMembersController,
+  patchMemberController,
   postMemberController,
 } from "../controllers/members.controller";
 
@@ -11,5 +13,7 @@ const membersRouter = new Hono();
 membersRouter.get("/", authMiddleware, getMembersController);
 membersRouter.get("/:id", authMiddleware, getMemberController);
 membersRouter.post("/", authMiddleware, postMemberController);
+membersRouter.patch("/:id", authMiddleware, patchMemberController);
+membersRouter.delete("/:id", authMiddleware, deleteMemberController);
 
 export default membersRouter;

--- a/src/schemas/members.schema.ts
+++ b/src/schemas/members.schema.ts
@@ -1,4 +1,4 @@
-import { createInsertSchema } from "drizzle-zod";
+import { createInsertSchema, createUpdateSchema } from "drizzle-zod";
 import { dbSchema } from "../db";
 
 export const memberInsertSchema = createInsertSchema(dbSchema.members, {
@@ -6,3 +6,12 @@ export const memberInsertSchema = createInsertSchema(dbSchema.members, {
   nickname: (schema) => schema.nonempty("Nickname cannot be empty"),
   birthDate: (schema) => schema.nonempty("Birth date cannot be empty"),
 });
+
+export const memberUpdateSchema = createUpdateSchema(dbSchema.members)
+  .omit({
+    id: true,
+    vinculationCode: true,
+    createdAt: true,
+    updatedAt: true,
+  })
+  .strict();

--- a/src/schemas/members.schema.ts
+++ b/src/schemas/members.schema.ts
@@ -1,0 +1,8 @@
+import { createInsertSchema } from "drizzle-zod";
+import { dbSchema } from "../db";
+
+export const memberInsertSchema = createInsertSchema(dbSchema.members, {
+  fullName: (schema) => schema.nonempty("Full name cannot be empty"),
+  nickname: (schema) => schema.nonempty("Nickname cannot be empty"),
+  birthDate: (schema) => schema.nonempty("Birth date cannot be empty"),
+});

--- a/src/tests/auth.router.test.ts
+++ b/src/tests/auth.router.test.ts
@@ -1,31 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import app from "../app";
+import { randomUUID } from "crypto";
 import { db, dbSchema } from "../db";
-import type { LoginInput, RegisterInput } from "../schemas/auth.schema";
 import type {
   AuthLoginPostResponse,
   AuthRegisterPostResponse,
 } from "../types/auth";
 import type { ErrorResponse } from "../types/error";
-import { createTestMember, createTestUser, loginTestUser } from "../utils/test";
 import type { Member } from "../types/member";
-import { randomUUID } from "crypto";
-
-const mockRequest: RegisterInput = {
-  email: "user@email.com",
-  password: "password",
-  vinculationCode: "5121caa3-3682-4381-8b97-2ccba11af93c",
-};
-
-const mockLogin: LoginInput = {
-  email: "user@email.com",
-  password: "password",
-};
+import {
+  createTestMember,
+  createTestUser,
+  loginTestUser,
+  seedTestMember,
+} from "../utils/test";
 
 let member: Member;
+let token: string;
 
 beforeEach(async () => {
-  member = await createTestMember();
+  member = await seedTestMember();
+  await createTestUser({ email: "admin@email.com" }, member.vinculationCode);
+  const response = await loginTestUser("admin@email.com", "password");
+  if ("token" in response.data) {
+    token = response.data.token;
+  } else {
+    throw new Error(
+      "Failed to login test user: " + JSON.stringify(response.data),
+    );
+  }
 });
 
 afterEach(async () => {
@@ -38,7 +40,9 @@ describe("POST /auth/register", () => {
     let response: Response;
     let data: AuthRegisterPostResponse;
     beforeEach(async () => {
-      const result = await createTestUser({}, member.vinculationCode);
+      const vinculationCode = randomUUID();
+      await createTestMember({}, vinculationCode, token);
+      const result = await createTestUser({}, vinculationCode);
       response = result.response;
       data = result.data as AuthRegisterPostResponse;
     });
@@ -140,12 +144,14 @@ describe("POST /auth/register", () => {
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      const newMember = await createTestMember({
-        vinculationCode: "dc7994bd-77fa-479b-88a7-bcafc4ed6f26",
-      });
-      await createTestUser({}, member.vinculationCode);
+      const vinculationCode = randomUUID();
+      await createTestMember({}, vinculationCode, token);
+      await createTestUser({}, vinculationCode);
 
-      const result = await createTestUser({}, newMember.vinculationCode);
+      const result = await createTestUser(
+        { email: "user@email.com" },
+        vinculationCode,
+      );
       response = result.response;
       data = result.data as ErrorResponse;
     });
@@ -166,7 +172,9 @@ describe("POST /auth/login", () => {
     let data: AuthLoginPostResponse;
 
     beforeEach(async () => {
-      await createTestUser({}, member.vinculationCode);
+      const vinculationCode = randomUUID();
+      await createTestMember({}, vinculationCode, token);
+      await createTestUser({}, vinculationCode);
 
       const result = await loginTestUser("user@email.com", "password");
       response = result.response;
@@ -185,7 +193,7 @@ describe("POST /auth/login", () => {
     it("should return the user info", () => {
       expect(data).toHaveProperty("user");
       expect(data.user).toMatchObject({
-        email: mockLogin.email,
+        email: "user@email.com",
         role: expect.any(String),
         id: expect.any(String),
       });

--- a/src/tests/auth.router.test.ts
+++ b/src/tests/auth.router.test.ts
@@ -285,7 +285,7 @@ describe("POST /auth/login", () => {
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      const result = await loginTestUser("notanemail", undefined);
+      const result = await loginTestUser("user@email.com", undefined);
       response = result.response;
       data = result.data as ErrorResponse;
     });

--- a/src/tests/auth.router.test.ts
+++ b/src/tests/auth.router.test.ts
@@ -7,6 +7,9 @@ import type {
   AuthRegisterPostResponse,
 } from "../types/auth";
 import type { ErrorResponse } from "../types/error";
+import { createTestMember, createTestUser, loginTestUser } from "../utils/test";
+import type { Member } from "../types/member";
+import { randomUUID } from "crypto";
 
 const mockRequest: RegisterInput = {
   email: "user@email.com",
@@ -19,14 +22,10 @@ const mockLogin: LoginInput = {
   password: "password",
 };
 
+let member: Member;
+
 beforeEach(async () => {
-  await db.insert(dbSchema.members).values({
-    rank: "tuno",
-    birthDate: "2000-01-01",
-    nickname: "testnick",
-    fullName: "Test User",
-    vinculationCode: mockRequest.vinculationCode,
-  });
+  member = await createTestMember();
 });
 
 afterEach(async () => {
@@ -39,12 +38,9 @@ describe("POST /auth/register", () => {
     let response: Response;
     let data: AuthRegisterPostResponse;
     beforeEach(async () => {
-      response = await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(mockRequest),
-      });
-      data = (await response.json()) as AuthRegisterPostResponse;
+      const result = await createTestUser({}, member.vinculationCode);
+      response = result.response;
+      data = result.data as AuthRegisterPostResponse;
     });
 
     it("should respond with 201 Created", () => {
@@ -61,13 +57,12 @@ describe("POST /auth/register", () => {
     let response: Response;
     let data: ErrorResponse;
     beforeEach(async () => {
-      const badRequest = { ...mockRequest, email: "invalid-email" };
-      response = await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(badRequest),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await createTestUser(
+        { email: "invalid-email" },
+        member.vinculationCode,
+      );
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {
@@ -84,13 +79,12 @@ describe("POST /auth/register", () => {
     let response: Response;
     let data: ErrorResponse;
     beforeEach(async () => {
-      const badRequest = { ...mockRequest, password: "1234" };
-      response = await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(badRequest),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await createTestUser(
+        { password: "1234" },
+        member.vinculationCode,
+      );
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {
@@ -109,16 +103,9 @@ describe("POST /auth/register", () => {
     let response: Response;
     let data: ErrorResponse;
     beforeEach(async () => {
-      const badRequest = {
-        ...mockRequest,
-        vinculationCode: "invalid-vinculation-code",
-      };
-      response = await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(badRequest),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await createTestUser({}, "invalid-vinculation-code");
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {
@@ -134,16 +121,9 @@ describe("POST /auth/register", () => {
     let response: Response;
     let data: ErrorResponse;
     beforeEach(async () => {
-      const badRequest = {
-        ...mockRequest,
-        vinculationCode: "a6c56b4c-5234-4fbb-bf87-dacef19e89b2",
-      };
-      response = await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(badRequest),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await createTestUser({}, randomUUID());
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {
@@ -160,30 +140,14 @@ describe("POST /auth/register", () => {
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      await db.insert(dbSchema.members).values({
-        rank: "tuno",
-        birthDate: "2000-01-01",
-        nickname: "testnick2",
-        fullName: "Test User 2",
+      const newMember = await createTestMember({
         vinculationCode: "dc7994bd-77fa-479b-88a7-bcafc4ed6f26",
       });
+      await createTestUser({}, member.vinculationCode);
 
-      await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(mockRequest),
-      });
-
-      response = await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...mockRequest,
-          vinculationCode: "dc7994bd-77fa-479b-88a7-bcafc4ed6f26",
-        }),
-      });
-
-      data = (await response.json()) as ErrorResponse;
+      const result = await createTestUser({}, newMember.vinculationCode);
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {
@@ -202,22 +166,11 @@ describe("POST /auth/login", () => {
     let data: AuthLoginPostResponse;
 
     beforeEach(async () => {
-      await app.request("/auth/register", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(mockRequest),
-      });
+      await createTestUser({}, member.vinculationCode);
 
-      response = await app.request("/auth/login", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(mockLogin),
-      });
-      data = (await response.json()) as AuthLoginPostResponse;
+      const result = await loginTestUser("user@email.com", "password");
+      response = result.response;
+      data = result.data as AuthLoginPostResponse;
     });
 
     it("should respond with 200 OK", () => {
@@ -243,12 +196,9 @@ describe("POST /auth/login", () => {
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      response = await app.request("/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...mockLogin, email: "nouser@email.com" }),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await loginTestUser("nouser@email.com", "password");
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 401 Unauthorized", () => {
@@ -265,18 +215,11 @@ describe("POST /auth/login", () => {
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      await app.request("/auth/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(mockRequest),
-      });
+      await createTestUser({}, member.vinculationCode);
 
-      response = await app.request("/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...mockLogin, password: "wrongpassword" }),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await loginTestUser("user@email.com", "wrongpassword");
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 401 Unauthorized", () => {
@@ -293,12 +236,9 @@ describe("POST /auth/login", () => {
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      response = await app.request("/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...mockLogin, email: "notanemail" }),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await loginTestUser("notanemail", "password");
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {
@@ -311,17 +251,35 @@ describe("POST /auth/login", () => {
     });
   });
 
+  describe("when email is missing", () => {
+    let response: Response;
+    let data: ErrorResponse;
+
+    beforeEach(async () => {
+      const result = await loginTestUser(undefined, "password");
+      response = result.response;
+      data = result.data as ErrorResponse;
+    });
+
+    it("should respond with 400 Bad Request", () => {
+      expect(response.status).toBe(400);
+    });
+
+    it("should return a validation error message", () => {
+      expect(data.error.message).toBe("Validation failed");
+      expect(data.error.details?.email).toContain(
+        "Invalid input: expected string, received undefined",
+      );
+    });
+  });
   describe("when password is missing", () => {
     let response: Response;
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      response = await app.request("/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: mockLogin.email }),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await loginTestUser("notanemail", undefined);
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {
@@ -341,12 +299,9 @@ describe("POST /auth/login", () => {
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      response = await app.request("/auth/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: mockLogin.email, password: "1234" }),
-      });
-      data = (await response.json()) as ErrorResponse;
+      const result = await loginTestUser("user@email.com", "1234");
+      response = result.response;
+      data = result.data as ErrorResponse;
     });
 
     it("should respond with 400 Bad Request", () => {

--- a/src/tests/events.router.test.ts
+++ b/src/tests/events.router.test.ts
@@ -2,59 +2,33 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import app from "../app";
 import { ERROR_CODES } from "../constants/error-codes";
 import { db, dbSchema } from "../db";
-import type { AuthLoginPostResponse } from "../types/auth";
 import type { ErrorResponse } from "../types/error";
 import type {
   Event,
   EventPostResponse,
   EventsGetResponse,
 } from "../types/event";
-
-const mockRequest = {
-  name: "Festival 26 años",
-  date: "2025-05-28T13:05:00.000Z",
-  location: "Universidad de La Sabana",
-  type: "festival",
-};
-
-const vinculationCode = "5121caa3-3682-4381-8b97-2ccba11af93c";
-const mockUser = {
-  email: "user@email.com",
-  password: "password",
-};
+import {
+  createTestEvent,
+  createTestMember,
+  createTestUser,
+  defaultEventData,
+  loginTestUser,
+} from "../utils/test";
 
 let token: string;
 
 beforeEach(async () => {
-  await db.insert(dbSchema.members).values({
-    rank: "tuno",
-    birthDate: "2000-01-01",
-    nickname: "testnick",
-    fullName: "Test User",
-    vinculationCode,
-  });
-
-  await app.request("/auth/register", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      ...mockUser,
-      vinculationCode,
-    }),
-  });
-
-  const loginResponse = await app.request("/auth/login", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(mockUser),
-  });
-
-  const loginData = (await loginResponse.json()) as AuthLoginPostResponse;
-  token = loginData.token;
+  const member = await createTestMember();
+  await createTestUser({}, member.vinculationCode);
+  const response = await loginTestUser("user@email.com", "password");
+  if ("token" in response.data) {
+    token = response.data.token;
+  } else {
+    throw new Error(
+      "Failed to login test user: " + JSON.stringify(response.data),
+    );
+  }
 });
 
 afterEach(async () => {
@@ -64,7 +38,7 @@ afterEach(async () => {
 });
 
 function testMissingField(
-  field: keyof typeof mockRequest,
+  field: keyof typeof defaultEventData,
   expectedError: Record<string, string[]>,
 ) {
   describe(`when the request is missing the ${field} field`, () => {
@@ -72,7 +46,7 @@ function testMissingField(
     let data: ErrorResponse;
 
     beforeEach(async () => {
-      const { [field]: _, ...invalidRequest } = mockRequest;
+      const { [field]: _, ...invalidRequest } = defaultEventData;
       response = await app.request("/events", {
         method: "POST",
         headers: {
@@ -106,16 +80,9 @@ describe("POST /events", () => {
     let data: EventPostResponse;
 
     beforeEach(async () => {
-      response = await app.request("/events", {
-        method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(mockRequest),
-      });
-
-      data = (await response.json()) as EventPostResponse;
+      const event = await createTestEvent({}, token);
+      response = event.response;
+      data = event.data;
     });
 
     it("should respond with 201 Created", () => {
@@ -161,11 +128,10 @@ describe("GET /events", () => {
   describe("when there are no events", () => {
     it("should return 200 OK and an empty events array", async () => {
       const response = await app.request("/events", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
       });
       const data = (await response.json()) as EventsGetResponse;
+
       expect(response.status).toBe(200);
       expect(data.events).toBeArray();
       expect(data.events).toBeEmpty();
@@ -179,19 +145,9 @@ describe("GET /events", () => {
     let event: Event;
 
     beforeEach(async () => {
-      await app.request("/events", {
-        method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(mockRequest),
-      });
-
+      await createTestEvent({}, token);
       response = await app.request("/events", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
       });
       data = (await response.json()) as EventsGetResponse;
       event = data.events.at(0)!;
@@ -204,7 +160,6 @@ describe("GET /events", () => {
     it("should return the created event with correct fields and values", () => {
       expect(data.events).toBeArray();
       expect(data.count).toBe(1);
-      expect(event.name).toBe(mockRequest.name);
     });
 
     it("should set status to 'por_confirmar' and isInternational to false by default", () => {
@@ -220,24 +175,12 @@ describe("GET /events/:id", () => {
     let response: Response;
     let event: Event;
     beforeEach(async () => {
-      const postResponse = await app.request("/events", {
-        method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(mockRequest),
-      });
-      const postData = (await postResponse.json()) as EventPostResponse;
+      const { data } = await createTestEvent({}, token);
       const getResponse = await app.request("/events", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
       });
       const getData = (await getResponse.json()) as EventsGetResponse;
-      const foundEvent = getData.events.find(
-        (event) => event.id === postData.id,
-      );
+      const foundEvent = getData.events.find((event) => event.id === data.id);
 
       if (!foundEvent) {
         throw new Error("Created event not found in events list");
@@ -245,9 +188,7 @@ describe("GET /events/:id", () => {
       createdEvent = foundEvent;
 
       response = await app.request(`/events/${createdEvent.id}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
       });
       event = (await response.json()) as Event;
     });
@@ -263,9 +204,7 @@ describe("GET /events/:id", () => {
   describe("when the id is not an uuid", () => {
     it("should respond with 400 Bad Request", async () => {
       const response = await app.request("/events/bad-formated-id", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { Authorization: `Bearer ${token}` },
       });
       expect(response.status).toBe(400);
 
@@ -297,17 +236,9 @@ describe("PATCH /events/:id", () => {
     let patchData: Event;
 
     beforeEach(async () => {
-      const postResponse = await app.request("/events", {
-        method: "POST",
-        headers: {
-          "Content-type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(mockRequest),
-      });
-      const postData = (await postResponse.json()) as EventPostResponse;
+      const { data } = await createTestEvent({}, token);
 
-      patchResponse = await app.request(`/events/${postData.id}`, {
+      patchResponse = await app.request(`/events/${data.id}`, {
         method: "PATCH",
         headers: {
           "Content-type": "application/json",

--- a/src/tests/events.router.test.ts
+++ b/src/tests/events.router.test.ts
@@ -10,7 +10,7 @@ import type {
 } from "../types/event";
 import {
   createTestEvent,
-  createTestMember,
+  seedTestMember,
   createTestUser,
   defaultEventData,
   loginTestUser,
@@ -19,7 +19,7 @@ import {
 let token: string;
 
 beforeEach(async () => {
-  const member = await createTestMember();
+  const member = await seedTestMember();
   await createTestUser({}, member.vinculationCode);
   const response = await loginTestUser("user@email.com", "password");
   if ("token" in response.data) {

--- a/src/tests/members.router.test.ts
+++ b/src/tests/members.router.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { randomUUID } from "crypto";
 import app from "../app";
 import { db, dbSchema } from "../db";
 import type { AuthLoginPostResponse } from "../types/auth";
+import type { ErrorResponse } from "../types/error";
 import type {
   Member,
+  MemberDeleteResponse,
+  MemberPatchResponse,
   MemberPostResponse,
   MembersGetResponse,
 } from "../types/member";
-import { seedTestMember, createTestUser, loginTestUser } from "../utils/test";
-import type { ErrorResponse } from "../types/error";
-import { randomUUID } from "crypto";
+import {
+  createTestMember,
+  createTestUser,
+  loginTestUser,
+  seedTestMember,
+} from "../utils/test";
 
 let user: AuthLoginPostResponse;
 
@@ -52,10 +59,15 @@ describe("GET /members", () => {
 describe("GET /members/:id", () => {
   describe("when the member exist", () => {
     let response: Response;
-    let data: any;
+    let data: Member;
     let memberId: string;
     beforeEach(async () => {
-      const member = await seedTestMember();
+      const vinculationCode = randomUUID();
+      const { data: member } = await createTestMember(
+        {},
+        vinculationCode,
+        user.token,
+      );
       memberId = member.id;
 
       response = await app.request(`/members/${memberId}`, {
@@ -63,7 +75,7 @@ describe("GET /members/:id", () => {
           Authorization: `Bearer ${user.token}`,
         },
       });
-      data = await response.json();
+      data = (await response.json()) as Member;
     });
 
     it("should respond with 200 OK", () => {
@@ -108,6 +120,169 @@ describe("POST /members", () => {
       expect(data).toHaveProperty("id");
       expect(typeof data.id).toBe("string");
       expect(data.message).toBe("Member created");
+    });
+  });
+});
+
+describe("PATCH /members/:id", () => {
+  describe("when the member exists and the request is valid", () => {
+    let response: Response;
+    let data: MemberPatchResponse;
+    let memberId: string;
+
+    beforeEach(async () => {
+      const vinculationCode = randomUUID();
+      const { data: member } = await createTestMember(
+        {},
+        vinculationCode,
+        user.token,
+      );
+      memberId = member.id;
+
+      response = await app.request(`/members/${memberId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({ nickname: "updatednick" }),
+      });
+      data = (await response.json()) as MemberPatchResponse;
+    });
+
+    it("should respond with 200 OK", () => {
+      expect(response.status).toBe(200);
+    });
+
+    it("should update and return the member", () => {
+      expect(data.id).toBe(memberId);
+      expect(data.message).toBe("Member updated");
+    });
+  });
+
+  describe("when the member does not exist", () => {
+    let response: Response;
+    let data: ErrorResponse;
+    const fakeId = "38bd666b-cf64-41d8-8d79-ffffffffffff";
+
+    beforeEach(async () => {
+      response = await app.request(`/members/${fakeId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({ nickname: "updatednick" }),
+      });
+      data = (await response.json()) as ErrorResponse;
+    });
+
+    it("should respond with 404 Not Found", () => {
+      expect(response.status).toBe(404);
+      expect(data.error.message).toBe("Member not found");
+    });
+  });
+
+  describe("when the request body is invalid", () => {
+    let response: Response;
+    let data: ErrorResponse;
+    let memberId: string;
+
+    beforeEach(async () => {
+      const vinculationCode = randomUUID();
+      const { data: member } = await createTestMember(
+        {},
+        vinculationCode,
+        user.token,
+      );
+      memberId = member.id;
+
+      response = await app.request(`/members/${memberId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({ nickname: null }),
+      });
+      data = (await response.json()) as ErrorResponse;
+    });
+
+    it("should respond with 400 Bad Request", () => {
+      expect(response.status).toBe(400);
+      expect(data.error.message).toBe("Validation failed");
+      expect(data.error.details?.nickname).toBeDefined();
+    });
+  });
+});
+
+describe("DELETE /members/:id", () => {
+  describe("when the member exists", () => {
+    let response: Response;
+    let data: MemberDeleteResponse;
+    let memberId: string;
+    let deletedMember: Member;
+
+    beforeEach(async () => {
+      const vinculationCode = randomUUID();
+      const { data: member } = await createTestMember(
+        {},
+        vinculationCode,
+        user.token,
+      );
+      memberId = member.id;
+
+      response = await app.request(`/members/${memberId}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+
+      data = (await response.json()) as MemberDeleteResponse;
+
+      const deletedMemberResponse = await app.request(`/members/${memberId}`, {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+
+      const deletedMemberData = (await deletedMemberResponse.json()) as Member;
+      deletedMember = deletedMemberData;
+    });
+
+    it("should respond with 200 OK", () => {
+      expect(response.status).toBe(200);
+    });
+
+    it("should return the member id and a message", () => {
+      expect(data).toHaveProperty("id", memberId);
+      expect(data).toHaveProperty("message", "Member deactivated");
+    });
+
+    it("should set isActive to false in the database", async () => {
+      expect(deletedMember.isActive).toBe(false);
+    });
+  });
+
+  describe("when the member does not exist", () => {
+    let response: Response;
+    let data: ErrorResponse;
+    const fakeId = "38bd666b-cf64-41d8-8d79-ffffffffffff";
+
+    beforeEach(async () => {
+      response = await app.request(`/members/${fakeId}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+      data = (await response.json()) as ErrorResponse;
+    });
+
+    it("should respond with 404 Not Found", () => {
+      expect(response.status).toBe(404);
+      expect(data.error.message).toBe("Member not found");
     });
   });
 });

--- a/src/tests/members.router.test.ts
+++ b/src/tests/members.router.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import app from "../app";
+import { db, dbSchema } from "../db";
+import type { AuthLoginPostResponse } from "../types/auth";
+import type {
+  Member,
+  MemberPostResponse,
+  MembersGetResponse,
+} from "../types/member";
+import { seedTestMember, createTestUser, loginTestUser } from "../utils/test";
+import type { ErrorResponse } from "../types/error";
+import { randomUUID } from "crypto";
+
+let user: AuthLoginPostResponse;
+
+beforeEach(async () => {
+  const member = await seedTestMember();
+  await createTestUser({}, member.vinculationCode);
+  const { data } = await loginTestUser("user@email.com", "password");
+  user = data as AuthLoginPostResponse;
+});
+afterEach(async () => {
+  await db.delete(dbSchema.users);
+  await db.delete(dbSchema.members);
+});
+
+describe("GET /members", () => {
+  describe("when there is at least one member", () => {
+    let response: Response;
+    let data: MembersGetResponse;
+
+    beforeEach(async () => {
+      response = await app.request("/members", {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+      data = (await response.json()) as MembersGetResponse;
+    });
+
+    it("should respond with 200 OK", () => {
+      expect(response.status).toBe(200);
+    });
+
+    it("should return an array of members", () => {
+      expect(data.members).toBeArray();
+      expect(data.count).toBe(1);
+    });
+  });
+});
+
+describe("GET /members/:id", () => {
+  describe("when the member exist", () => {
+    let response: Response;
+    let data: any;
+    let memberId: string;
+    beforeEach(async () => {
+      const member = await seedTestMember();
+      memberId = member.id;
+
+      response = await app.request(`/members/${memberId}`, {
+        headers: {
+          Authorization: `Bearer ${user.token}`,
+        },
+      });
+      data = await response.json();
+    });
+
+    it("should respond with 200 OK", () => {
+      expect(response.status).toBe(200);
+    });
+
+    it("should return the expected object", () => {
+      expect(data.id).toBe(memberId);
+    });
+  });
+  describe.todo("when the id is not an uuid", () => {});
+  describe.todo("when the member does not exist", () => {});
+});
+
+describe("POST /members", () => {
+  describe("when the request is valid", () => {
+    let response: Response;
+    let data: MemberPostResponse;
+
+    beforeEach(async () => {
+      response = await app.request("/members", {
+        method: "POST",
+        headers: {
+          "Content-type": "application/json",
+          Authorization: `Bearer ${user.token}`,
+        },
+        body: JSON.stringify({
+          rank: "tuno",
+          birthDate: "2000-01-01",
+          nickname: "new",
+          fullName: "New User",
+        }),
+      });
+      data = (await response.json()) as MemberPostResponse;
+    });
+
+    it("should respond with 201 Created", () => {
+      expect(response.status).toBe(201);
+    });
+
+    it("should return a confirmation message and the member id", () => {
+      expect(data).toHaveProperty("id");
+      expect(typeof data.id).toBe("string");
+      expect(data.message).toBe("Member created");
+    });
+  });
+});

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -1,0 +1,5 @@
+import { dbSchema } from "../db";
+
+export type Member = typeof dbSchema.members.$inferSelect;
+
+export type MemberInsert = typeof dbSchema.members.$inferInsert;

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -3,3 +3,13 @@ import { dbSchema } from "../db";
 export type Member = typeof dbSchema.members.$inferSelect;
 
 export type MemberInsert = typeof dbSchema.members.$inferInsert;
+
+export type MembersGetResponse = {
+  members: Member[];
+  count: number;
+};
+
+export type MemberPostResponse = {
+  id: string;
+  message: string;
+};

--- a/src/types/member.ts
+++ b/src/types/member.ts
@@ -13,3 +13,13 @@ export type MemberPostResponse = {
   id: string;
   message: string;
 };
+
+export type MemberPatchResponse = {
+  id: string;
+  message: string;
+};
+
+export type MemberDeleteResponse = {
+  id: string;
+  message: string;
+};

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -1,0 +1,82 @@
+import app from "../app";
+import { db, dbSchema } from "../db";
+import type {
+  AuthLoginPostResponse,
+  AuthRegisterPostResponse,
+} from "../types/auth";
+import { randomUUID } from "crypto";
+import type { MemberInsert } from "../types/member";
+import type { EventPostResponse } from "../types/event";
+import type { ErrorResponse } from "../types/error";
+
+export async function createTestMember(memberData = {}) {
+  const defaultMember: MemberInsert = {
+    rank: "tuno",
+    birthDate: "2000-01-01",
+    nickname: "testnick",
+    fullName: "Test User",
+    vinculationCode: randomUUID(),
+    ...memberData,
+  };
+  const [member] = await db
+    .insert(dbSchema.members)
+    .values(defaultMember)
+    .returning();
+
+  if (!member) throw new Error("Failed to create test member");
+
+  return member;
+}
+
+export async function createTestUser(userData = {}, vinculationCode: string) {
+  const defaultUser = {
+    email: "user@email.com",
+    password: "password",
+    ...userData,
+    vinculationCode,
+  };
+  const response = await app.request("/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(defaultUser),
+  });
+  const data = (await response.json()) as
+    | AuthRegisterPostResponse
+    | ErrorResponse;
+  return { response, data, user: defaultUser };
+}
+
+export async function loginTestUser(
+  email: string | undefined,
+  password: string | undefined,
+) {
+  const response = await app.request("/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  const data = (await response.json()) as AuthLoginPostResponse | ErrorResponse;
+
+  return { response, data };
+}
+
+export const defaultEventData = {
+  name: "Festival 26 años",
+  date: "2025-05-28T13:05:00.000Z",
+  location: "Universidad de La Sabana",
+  type: "festival",
+};
+
+export async function createTestEvent(eventData = {}, token: string) {
+  const response = await app.request("/events", {
+    method: "POST",
+    headers: {
+      "Content-type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ ...defaultEventData, eventData }),
+  });
+  const data = (await response.json()) as EventPostResponse;
+  return { response, data };
+}

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -98,7 +98,7 @@ export async function createTestEvent(eventData = {}, token: string) {
       "Content-type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ ...defaultEventData, eventData }),
+    body: JSON.stringify({ ...defaultEventData, ...eventData }),
   });
   const data = (await response.json()) as EventPostResponse;
   return { response, data };

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -4,19 +4,16 @@ import type {
   AuthLoginPostResponse,
   AuthRegisterPostResponse,
 } from "../types/auth";
-import { randomUUID } from "crypto";
-import type { MemberInsert } from "../types/member";
+import type { MemberInsert, MemberPostResponse } from "../types/member";
 import type { EventPostResponse } from "../types/event";
 import type { ErrorResponse } from "../types/error";
 
-export async function createTestMember(memberData = {}) {
+export async function seedTestMember() {
   const defaultMember: MemberInsert = {
     rank: "tuno",
     birthDate: "2000-01-01",
     nickname: "testnick",
     fullName: "Test User",
-    vinculationCode: randomUUID(),
-    ...memberData,
   };
   const [member] = await db
     .insert(dbSchema.members)
@@ -26,6 +23,32 @@ export async function createTestMember(memberData = {}) {
   if (!member) throw new Error("Failed to create test member");
 
   return member;
+}
+
+export async function createTestMember(
+  memberData = {},
+  vinculationCode: string,
+  token: string,
+) {
+  const defaultMember: MemberInsert = {
+    rank: "tuno",
+    birthDate: "2000-01-01",
+    nickname: "new",
+    fullName: "New User",
+    vinculationCode,
+    ...memberData,
+  };
+  const response = await app.request("/members", {
+    method: "POST",
+    headers: {
+      "Content-type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(defaultMember),
+  });
+  const data = (await response.json()) as MemberPostResponse;
+
+  return { response, data };
 }
 
 export async function createTestUser(userData = {}, vinculationCode: string) {


### PR DESCRIPTION
## Add Members Get and Post Endpoints, Validation, Types & Tests

### Summary

- A new members table migration with `isActive` flag
- Zod validation schema for member inserts
- Controllers & router for `GET /members`, `GET /members/:id` and `POST /members`
- TypeScript types for requests & responses
- Two new test-helpers `seedTestMember` & `createTestMember`
- End-to-end tests covering happy paths and TODOs for error cases
- Updates to existing Auth & Events tests to use the new seed/helper patterns

### Tests:
<img width="988" alt="image" src="https://github.com/user-attachments/assets/46ab395e-1301-4bb0-abdb-3815cf1d4572" />
