### PR TITLE
Feature/clients and serenades

### DIFF
--- a/drizzle/0005_productive_shooting_star.sql
+++ b/drizzle/0005_productive_shooting_star.sql
@@ -1,0 +1,27 @@
+CREATE TYPE "public"."serenade_occasion" AS ENUM('cumpleanos', 'matrimonio', 'grado', 'quince_anos', 'aniversario', 'despedida', 'otro');--> statement-breakpoint
+CREATE TABLE "clients" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"phone" varchar(20) NOT NULL,
+	"email" varchar(255),
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "serenade_bookings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"client_id" uuid NOT NULL,
+	"price" integer NOT NULL,
+	"transportation_cost" integer DEFAULT 0,
+	"occasion" "serenade_occasion" NOT NULL,
+	"occasion_details" text,
+	"special_requests" text,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "serenade_bookings_event_id_unique" UNIQUE("event_id")
+);
+--> statement-breakpoint
+ALTER TABLE "serenade_bookings" ADD CONSTRAINT "serenade_bookings_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "serenade_bookings" ADD CONSTRAINT "serenade_bookings_client_id_fkey" FOREIGN KEY ("client_id") REFERENCES "public"."clients"("id") ON DELETE restrict ON UPDATE no action;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,734 @@
+{
+  "id": "89210180-b39f-4c2a-a796-8772ab81ed80",
+  "prevId": "a041d995-4d3a-4b31-ad29-f013ebf09d54",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.attendances": {
+      "name": "attendances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "attendance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'por_confirmar'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attendances_event_id_fkey": {
+          "name": "attendances_event_id_fkey",
+          "tableFrom": "attendances",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendances_member_id_fkey": {
+          "name": "attendances_member_id_fkey",
+          "tableFrom": "attendances",
+          "tableTo": "members",
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendances_updated_by_fkey": {
+          "name": "attendances_updated_by_fkey",
+          "tableFrom": "attendances",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendances_event_id_member_id_key": {
+          "name": "attendances_event_id_member_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["event_id", "member_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_international": {
+          "name": "is_international",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'por_confirmar'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_created_by_fkey": {
+          "name": "events_created_by_fkey",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_updated_by_fkey": {
+          "name": "events_updated_by_fkey",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "raul": {
+          "name": "raul",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "member_rank",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_issued_at": {
+          "name": "document_issued_at",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eps": {
+          "name": "eps",
+          "type": "eps_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blood_type": {
+          "name": "blood_type",
+          "type": "blood_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "civil_status": {
+          "name": "civil_status",
+          "type": "civil_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partner_name": {
+          "name": "partner_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "children_names": {
+          "name": "children_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "beca_date": {
+          "name": "beca_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deceased_at": {
+          "name": "deceased_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vinculation_code": {
+          "name": "vinculation_code",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_raul_key": {
+          "name": "members_raul_key",
+          "nullsNotDistinct": false,
+          "columns": ["raul"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serenade_bookings": {
+      "name": "serenade_bookings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transportation_cost": {
+          "name": "transportation_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "occasion": {
+          "name": "occasion",
+          "type": "serenade_occasion",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occasion_details": {
+          "name": "occasion_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "special_requests": {
+          "name": "special_requests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "serenade_bookings_event_id_fkey": {
+          "name": "serenade_bookings_event_id_fkey",
+          "tableFrom": "serenade_bookings",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "serenade_bookings_client_id_fkey": {
+          "name": "serenade_bookings_client_id_fkey",
+          "tableFrom": "serenade_bookings",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "serenade_bookings_event_id_unique": {
+          "name": "serenade_bookings_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_member_id_fkey1": {
+          "name": "users_member_id_fkey1",
+          "tableFrom": "users",
+          "tableTo": "members",
+          "columnsFrom": ["member_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_member_id_unique": {
+          "name": "users_member_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["member_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attendance_status": {
+      "name": "attendance_status",
+      "schema": "public",
+      "values": ["asiste", "no_asiste", "por_confirmar", "no_responde"]
+    },
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": ["local", "google"]
+    },
+    "public.blood_type": {
+      "name": "blood_type",
+      "schema": "public",
+      "values": ["a+", "a-", "b+", "b-", "ab+", "ab-", "o+", "o-"]
+    },
+    "public.civil_status": {
+      "name": "civil_status",
+      "schema": "public",
+      "values": ["soltero", "casado", "divorciado"]
+    },
+    "public.eps_provider": {
+      "name": "eps_provider",
+      "schema": "public",
+      "values": [
+        "aliansalud",
+        "colmedica",
+        "compensar",
+        "sanitas",
+        "sura",
+        "salud_total",
+        "colpatria",
+        "coomeva",
+        "famisanar",
+        "medifiatc",
+        "cafesalud",
+        "susalud",
+        "asmetsalud",
+        "nueva_eps",
+        "sanidad_militar",
+        "sisben"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": ["por_confirmar", "confirmado", "realizado", "cancelado"]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "serenata",
+        "ensayo",
+        "festival",
+        "certamen",
+        "remate",
+        "parche",
+        "viaje"
+      ]
+    },
+    "public.member_rank": {
+      "name": "member_rank",
+      "schema": "public",
+      "values": ["aspirante", "bulto", "tuno"]
+    },
+    "public.serenade_occasion": {
+      "name": "serenade_occasion",
+      "schema": "public",
+      "values": [
+        "cumpleanos",
+        "matrimonio",
+        "grado",
+        "quince_anos",
+        "aniversario",
+        "despedida",
+        "otro"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "editor", "viewer"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1766261837857,
       "tag": "0004_wise_vargas",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1766558312666,
+      "tag": "0005_productive_shooting_star",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -7,7 +7,7 @@ import pingRouter from "../routers/ping.router";
 import attendancesRouter from "../routers/attendances.router";
 import usersRouter from "../routers/users.router";
 import clientsRouter from "../routers/clients.router";
-// import serenadeBookingsRouter from "../routers/serenade-bookings.router";
+import serenadeBookingsRouter from "../routers/serenade-bookings.router";
 
 const app = new Hono();
 
@@ -25,6 +25,6 @@ app.route("/auth", authRouter);
 app.route("/attendances", attendancesRouter);
 app.route("/users", usersRouter);
 app.route("/clients", clientsRouter);
-// app.route("/serenade-bookings", serenadeBookingsRouter);
+app.route("/serenade-bookings", serenadeBookingsRouter);
 
 export default app;

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -6,6 +6,8 @@ import membersRouter from "../routers/members.router";
 import pingRouter from "../routers/ping.router";
 import attendancesRouter from "../routers/attendances.router";
 import usersRouter from "../routers/users.router";
+import clientsRouter from "../routers/clients.router";
+// import serenadeBookingsRouter from "../routers/serenade-bookings.router";
 
 const app = new Hono();
 
@@ -22,5 +24,7 @@ app.route("/members", membersRouter);
 app.route("/auth", authRouter);
 app.route("/attendances", attendancesRouter);
 app.route("/users", usersRouter);
+app.route("/clients", clientsRouter);
+// app.route("/serenade-bookings", serenadeBookingsRouter);
 
 export default app;

--- a/src/controllers/clients.controller.ts
+++ b/src/controllers/clients.controller.ts
@@ -1,0 +1,241 @@
+import { eq, desc } from "drizzle-orm";
+import type { Context } from "hono";
+import { z } from "zod";
+import { db } from "../db";
+import { clients } from "../db/schema";
+import {
+  clientInsertSchema,
+  clientUpdateSchema,
+  clientIdSchema,
+} from "../schemas/clients.schema";
+import type { ApiResponse } from "../types/common";
+import type { Client, ClientsGetResponse } from "../types/client";
+
+export const getClients = async (c: Context): Promise<Response> => {
+  try {
+    const result = await db
+      .select()
+      .from(clients)
+      .orderBy(desc(clients.createdAt));
+    const response: ClientsGetResponse = {
+      items: result,
+      count: result.length,
+    };
+
+    return c.json<ApiResponse<ClientsGetResponse>>({
+      success: true,
+      data: response,
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to fetch clients",
+      },
+      500,
+    );
+  }
+};
+
+export const getClientById = async (c: Context): Promise<Response> => {
+  const id = c.req.param("id");
+  const idValidation = clientIdSchema.shape.id.safeParse(id);
+
+  if (!idValidation.success) {
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Invalid client ID format",
+      },
+      400,
+    );
+  }
+
+  try {
+    const result = await db.select().from(clients).where(eq(clients.id, id));
+
+    if (result.length === 0) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error: "Client not found",
+        },
+        404,
+      );
+    }
+
+    return c.json<ApiResponse<Client>>({
+      success: true,
+      data: result[0],
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to fetch client",
+      },
+      500,
+    );
+  }
+};
+
+export const createClient = async (c: Context): Promise<Response> => {
+  try {
+    const body = await c.req.json();
+    const validation = clientInsertSchema.safeParse(body);
+
+    if (!validation.success) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error:
+            "Validation failed: " + JSON.stringify(validation.error.flatten()),
+        },
+        400,
+      );
+    }
+
+    // Type assertion needed because optional().or(literal("")) creates a Union which Drizzle insert type might not perfectly infer as compatible with 'string | null | undefined'
+    const result = await db
+      .insert(clients)
+      .values(validation.data as any)
+      .returning();
+
+    return c.json<ApiResponse<Client>>(
+      {
+        success: true,
+        data: result[0],
+      },
+      201,
+    );
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to create client",
+      },
+      500,
+    );
+  }
+};
+
+export const updateClient = async (c: Context): Promise<Response> => {
+  const id = c.req.param("id");
+  const idValidation = clientIdSchema.shape.id.safeParse(id);
+
+  if (!idValidation.success) {
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Invalid client ID format",
+      },
+      400,
+    );
+  }
+
+  try {
+    const body = await c.req.json();
+    const validation = clientUpdateSchema.safeParse(body);
+
+    if (!validation.success) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error:
+            "Validation failed: " + JSON.stringify(validation.error.flatten()),
+        },
+        400,
+      );
+    }
+
+    const result = await db
+      .update(clients)
+      .set({ ...validation.data, updatedAt: new Date().toISOString() } as any)
+      .where(eq(clients.id, id))
+      .returning();
+
+    if (result.length === 0) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error: "Client not found",
+        },
+        404,
+      );
+    }
+
+    return c.json<ApiResponse<Client>>({
+      success: true,
+      data: result[0],
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to update client",
+      },
+      500,
+    );
+  }
+};
+
+export const deleteClient = async (c: Context): Promise<Response> => {
+  const id = c.req.param("id");
+  const idValidation = clientIdSchema.shape.id.safeParse(id);
+
+  if (!idValidation.success) {
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Invalid client ID format",
+      },
+      400,
+    );
+  }
+
+  try {
+    const result = await db
+      .delete(clients)
+      .where(eq(clients.id, id))
+      .returning();
+
+    if (result.length === 0) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error: "Client not found",
+        },
+        404,
+      );
+    }
+
+    return c.json<ApiResponse<Client>>({
+      success: true,
+      data: result[0],
+    });
+  } catch (error: any) {
+    if (error.code === "23503") {
+      // Foreign key violation
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error:
+            "Cannot delete client because they have associated serenade bookings.",
+        },
+        409,
+      );
+    }
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to delete client",
+      },
+      500,
+    );
+  }
+};

--- a/src/controllers/serenade-bookings.controller.ts
+++ b/src/controllers/serenade-bookings.controller.ts
@@ -1,0 +1,234 @@
+import { eq, desc } from "drizzle-orm";
+import type { Context } from "hono";
+import { db } from "../db";
+import { serenadeBookings } from "../db/schema";
+import {
+  serenadeBookingInsertSchema,
+  serenadeBookingUpdateSchema,
+  serenadeBookingIdSchema,
+} from "../schemas/serenade-bookings.schema";
+import type { ApiResponse } from "../types/common";
+import type {
+  SerenadeBooking,
+  SerenadeBookingsGetResponse,
+} from "../types/serenade-booking";
+
+export const getSerenadeBookings = async (c: Context): Promise<Response> => {
+  try {
+    const result = await db
+      .select()
+      .from(serenadeBookings)
+      .orderBy(desc(serenadeBookings.createdAt));
+    const response: SerenadeBookingsGetResponse = {
+      items: result,
+      count: result.length,
+    };
+
+    return c.json<ApiResponse<SerenadeBookingsGetResponse>>({
+      success: true,
+      data: response,
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to fetch serenade bookings",
+      },
+      500,
+    );
+  }
+};
+
+export const getSerenadeBookingById = async (c: Context): Promise<Response> => {
+  const id = c.req.param("id");
+  const idValidation = serenadeBookingIdSchema.shape.id.safeParse(id);
+
+  if (!idValidation.success) {
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Invalid serenade booking ID format",
+      },
+      400,
+    );
+  }
+
+  try {
+    const result = await db
+      .select()
+      .from(serenadeBookings)
+      .where(eq(serenadeBookings.id, id));
+
+    if (result.length === 0) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error: "Serenade booking not found",
+        },
+        404,
+      );
+    }
+
+    return c.json<ApiResponse<SerenadeBooking>>({
+      success: true,
+      data: result[0],
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to fetch serenade booking",
+      },
+      500,
+    );
+  }
+};
+
+export const createSerenadeBooking = async (c: Context): Promise<Response> => {
+  try {
+    const body = await c.req.json();
+    const validation = serenadeBookingInsertSchema.safeParse(body);
+
+    if (!validation.success) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error:
+            "Validation failed: " + JSON.stringify(validation.error.flatten()),
+        },
+        400,
+      );
+    }
+
+    const result = await db
+      .insert(serenadeBookings)
+      .values(validation.data)
+      .returning();
+
+    return c.json<ApiResponse<SerenadeBooking>>(
+      {
+        success: true,
+        data: result[0],
+      },
+      201,
+    );
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to create serenade booking",
+      },
+      500,
+    );
+  }
+};
+
+export const updateSerenadeBooking = async (c: Context): Promise<Response> => {
+  const id = c.req.param("id");
+  const idValidation = serenadeBookingIdSchema.shape.id.safeParse(id);
+
+  if (!idValidation.success) {
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Invalid serenade booking ID format",
+      },
+      400,
+    );
+  }
+
+  try {
+    const body = await c.req.json();
+    const validation = serenadeBookingUpdateSchema.safeParse(body);
+
+    if (!validation.success) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error:
+            "Validation failed: " + JSON.stringify(validation.error.flatten()),
+        },
+        400,
+      );
+    }
+
+    const result = await db
+      .update(serenadeBookings)
+      .set({ ...validation.data, updatedAt: new Date().toISOString() })
+      .where(eq(serenadeBookings.id, id))
+      .returning();
+
+    if (result.length === 0) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error: "Serenade booking not found",
+        },
+        404,
+      );
+    }
+
+    return c.json<ApiResponse<SerenadeBooking>>({
+      success: true,
+      data: result[0],
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to update serenade booking",
+      },
+      500,
+    );
+  }
+};
+
+export const deleteSerenadeBooking = async (c: Context): Promise<Response> => {
+  const id = c.req.param("id");
+  const idValidation = serenadeBookingIdSchema.shape.id.safeParse(id);
+
+  if (!idValidation.success) {
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Invalid serenade booking ID format",
+      },
+      400,
+    );
+  }
+
+  try {
+    const result = await db
+      .delete(serenadeBookings)
+      .where(eq(serenadeBookings.id, id))
+      .returning();
+
+    if (result.length === 0) {
+      return c.json<ApiResponse<null>>(
+        {
+          success: false,
+          error: "Serenade booking not found",
+        },
+        404,
+      );
+    }
+
+    return c.json<ApiResponse<SerenadeBooking>>({
+      success: true,
+      data: result[0],
+    });
+  } catch (error) {
+    console.error(error);
+    return c.json<ApiResponse<null>>(
+      {
+        success: false,
+        error: "Failed to delete serenade booking",
+      },
+      500,
+    );
+  }
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -70,6 +70,15 @@ export const eventType = pgEnum("event_type", [
 export const memberRank = pgEnum("member_rank", ["aspirante", "bulto", "tuno"]);
 export const userRole = pgEnum("user_role", ["admin", "editor", "viewer"]);
 export const authProvider = pgEnum("auth_provider", ["local", "google"]);
+export const serenadeOccasion = pgEnum("serenade_occasion", [
+  "cumpleanos",
+  "matrimonio",
+  "grado",
+  "quince_anos",
+  "aniversario",
+  "despedida",
+  "otro",
+]);
 
 export const users = pgTable(
   "users",
@@ -207,5 +216,56 @@ export const events = pgTable(
       foreignColumns: [users.id],
       name: "events_updated_by_fkey",
     }),
+  ],
+);
+
+export const clients = pgTable("clients", {
+  id: uuid().defaultRandom().primaryKey().notNull(),
+  name: text().notNull(),
+  phone: varchar({ length: 20 }).notNull(),
+  email: varchar({ length: 255 }),
+  notes: text(),
+  createdAt: timestamp("created_at", {
+    withTimezone: true,
+    mode: "string",
+  }).defaultNow(),
+  updatedAt: timestamp("updated_at", {
+    withTimezone: true,
+    mode: "string",
+  }).defaultNow(),
+});
+
+export const serenadeBookings = pgTable(
+  "serenade_bookings",
+  {
+    id: uuid().defaultRandom().primaryKey().notNull(),
+    eventId: uuid("event_id").notNull(),
+    clientId: uuid("client_id").notNull(),
+    price: integer().notNull(),
+    transportationCost: integer("transportation_cost").default(0),
+    occasion: serenadeOccasion().notNull(),
+    occasionDetails: text("occasion_details"),
+    specialRequests: text("special_requests"),
+    createdAt: timestamp("created_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+    updatedAt: timestamp("updated_at", {
+      withTimezone: true,
+      mode: "string",
+    }).defaultNow(),
+  },
+  (table) => [
+    foreignKey({
+      columns: [table.eventId],
+      foreignColumns: [events.id],
+      name: "serenade_bookings_event_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.clientId],
+      foreignColumns: [clients.id],
+      name: "serenade_bookings_client_id_fkey",
+    }).onDelete("restrict"),
+    unique("serenade_bookings_event_id_unique").on(table.eventId),
   ],
 );

--- a/src/routers/clients.router.ts
+++ b/src/routers/clients.router.ts
@@ -1,0 +1,19 @@
+import { authMiddleware } from "../middlewares/auth.middleware";
+import { Hono } from "hono";
+import {
+  getClients,
+  getClientById,
+  createClient,
+  updateClient,
+  deleteClient,
+} from "../controllers/clients.controller";
+
+const clientsRouter = new Hono();
+
+clientsRouter.get("/", authMiddleware, getClients);
+clientsRouter.get("/:id", authMiddleware, getClientById);
+clientsRouter.post("/", authMiddleware, createClient);
+clientsRouter.patch("/:id", authMiddleware, updateClient);
+clientsRouter.delete("/:id", authMiddleware, deleteClient);
+
+export default clientsRouter;

--- a/src/routers/serenade-bookings.router.ts
+++ b/src/routers/serenade-bookings.router.ts
@@ -1,0 +1,19 @@
+import { authMiddleware } from "../middlewares/auth.middleware";
+import { Hono } from "hono";
+import {
+  getSerenadeBookings,
+  getSerenadeBookingById,
+  createSerenadeBooking,
+  updateSerenadeBooking,
+  deleteSerenadeBooking,
+} from "../controllers/serenade-bookings.controller";
+
+const serenadeBookingsRouter = new Hono();
+
+serenadeBookingsRouter.get("/", authMiddleware, getSerenadeBookings);
+serenadeBookingsRouter.get("/:id", authMiddleware, getSerenadeBookingById);
+serenadeBookingsRouter.post("/", authMiddleware, createSerenadeBooking);
+serenadeBookingsRouter.patch("/:id", authMiddleware, updateSerenadeBooking);
+serenadeBookingsRouter.delete("/:id", authMiddleware, deleteSerenadeBooking);
+
+export default serenadeBookingsRouter;

--- a/src/schemas/clients.schema.ts
+++ b/src/schemas/clients.schema.ts
@@ -1,0 +1,19 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { clients } from "../db/schema";
+
+export const clientSelectSchema = createSelectSchema(clients);
+
+export const clientInsertSchema = createInsertSchema(clients, {
+  email: z.string().email().optional() as any,
+}).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const clientUpdateSchema = clientInsertSchema.partial();
+
+export const clientIdSchema = z.object({
+  id: z.string().uuid(),
+});

--- a/src/schemas/clients.schema.ts
+++ b/src/schemas/clients.schema.ts
@@ -4,12 +4,14 @@ import { clients } from "../db/schema";
 
 export const clientSelectSchema = createSelectSchema(clients);
 
-export const clientInsertSchema = createInsertSchema(clients, {
-  email: z.string().email().optional() as any,
-}).omit({
-  id: true,
-  createdAt: true,
-  updatedAt: true,
+export const clientInsertSchema = z.object({
+  name: z.string(),
+  phone: z.string().max(20),
+  email: z
+    .union([z.string().email(), z.literal("")])
+    .optional()
+    .nullable(),
+  notes: z.string().optional().nullable(),
 });
 
 export const clientUpdateSchema = clientInsertSchema.partial();

--- a/src/schemas/serenade-bookings.schema.ts
+++ b/src/schemas/serenade-bookings.schema.ts
@@ -1,0 +1,20 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { serenadeBookings } from "../db/schema";
+
+export const serenadeBookingSelectSchema = createSelectSchema(serenadeBookings);
+
+export const serenadeBookingInsertSchema = createInsertSchema(
+  serenadeBookings,
+).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const serenadeBookingUpdateSchema =
+  serenadeBookingInsertSchema.partial();
+
+export const serenadeBookingIdSchema = z.object({
+  id: z.string().uuid(),
+});

--- a/src/tests/clients.router.test.ts
+++ b/src/tests/clients.router.test.ts
@@ -1,18 +1,33 @@
 import { describe, expect, it, beforeAll, afterAll } from "bun:test";
 import app from "../app";
-import { db } from "../db";
+import { db, dbSchema } from "../db";
 import { clients } from "../db/schema";
 import type { ApiResponse } from "../types/common";
 import type { Client, ClientsGetResponse } from "../types/client";
+import { createTestUser, loginTestUser, seedTestMember } from "../utils/test";
+import type { Member } from "../types/member";
 
 describe("Clients Router", () => {
+  let token: string;
+  let member: Member;
+
   // Clean up database before and after tests
   const cleanup = async () => {
     await db.delete(clients);
+    await db.delete(dbSchema.users);
+    await db.delete(dbSchema.members);
   };
 
   beforeAll(async () => {
     await cleanup();
+    member = await seedTestMember();
+    await createTestUser({ email: "admin@email.com" }, member.vinculationCode);
+    const response = await loginTestUser("admin@email.com", "password");
+    if ("token" in response.data) {
+      token = response.data.token;
+    } else {
+      throw new Error("Failed to login test user");
+    }
   });
 
   afterAll(async () => {
@@ -31,7 +46,10 @@ describe("Clients Router", () => {
 
     const res = await app.request("/clients", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
       body: JSON.stringify(newClient),
     });
 
@@ -46,7 +64,9 @@ describe("Clients Router", () => {
   });
 
   it("GET /clients - should return a list of clients", async () => {
-    const res = await app.request("/clients");
+    const res = await app.request("/clients", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as ApiResponse<ClientsGetResponse>;
     expect(body.success).toBe(true);
@@ -57,7 +77,9 @@ describe("Clients Router", () => {
   });
 
   it("GET /clients/:id - should return a specific client", async () => {
-    const res = await app.request(`/clients/${createdClientId}`);
+    const res = await app.request(`/clients/${createdClientId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as ApiResponse<Client>;
     expect(body.success).toBe(true);
@@ -74,7 +96,10 @@ describe("Clients Router", () => {
 
     const res = await app.request(`/clients/${createdClientId}`, {
       method: "PATCH",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
       body: JSON.stringify(updateData),
     });
 
@@ -90,6 +115,7 @@ describe("Clients Router", () => {
   it("DELETE /clients/:id - should delete a client", async () => {
     const res = await app.request(`/clients/${createdClientId}`, {
       method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
     });
 
     expect(res.status).toBe(200);
@@ -97,7 +123,9 @@ describe("Clients Router", () => {
     expect(body.success).toBe(true);
 
     // Verify deletion
-    const checkRes = await app.request(`/clients/${createdClientId}`);
+    const checkRes = await app.request(`/clients/${createdClientId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
     expect(checkRes.status).toBe(404);
   });
 });

--- a/src/tests/clients.router.test.ts
+++ b/src/tests/clients.router.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import app from "../app";
+import { db } from "../db";
+import { clients } from "../db/schema";
+import type { ApiResponse } from "../types/common";
+import type { Client, ClientsGetResponse } from "../types/client";
+
+describe("Clients Router", () => {
+  // Clean up database before and after tests
+  const cleanup = async () => {
+    await db.delete(clients);
+  };
+
+  beforeAll(async () => {
+    await cleanup();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  let createdClientId: string;
+
+  it("POST /clients - should create a new client", async () => {
+    const newClient = {
+      name: "Test Client",
+      phone: "1234567890",
+      email: "test@client.com",
+      notes: "Test notes",
+    };
+
+    const res = await app.request("/clients", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newClient),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ApiResponse<Client>;
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveProperty("id");
+    if (body.data) {
+      expect(body.data.name).toBe(newClient.name);
+      createdClientId = body.data.id;
+    }
+  });
+
+  it("GET /clients - should return a list of clients", async () => {
+    const res = await app.request("/clients");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<ClientsGetResponse>;
+    expect(body.success).toBe(true);
+    if (body.data) {
+      expect(Array.isArray(body.data.items)).toBe(true);
+      expect(body.data.count).toBeGreaterThan(0);
+    }
+  });
+
+  it("GET /clients/:id - should return a specific client", async () => {
+    const res = await app.request(`/clients/${createdClientId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<Client>;
+    expect(body.success).toBe(true);
+    if (body.data) {
+      expect(body.data.id).toBe(createdClientId);
+    }
+  });
+
+  it("PATCH /clients/:id - should update client details", async () => {
+    const updateData = {
+      name: "Updated Client Name",
+      phone: "0987654321",
+    };
+
+    const res = await app.request(`/clients/${createdClientId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(updateData),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<Client>;
+    expect(body.success).toBe(true);
+    if (body.data) {
+      expect(body.data.name).toBe(updateData.name);
+      expect(body.data.phone).toBe(updateData.phone);
+    }
+  });
+
+  it("DELETE /clients/:id - should delete a client", async () => {
+    const res = await app.request(`/clients/${createdClientId}`, {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<Client>;
+    expect(body.success).toBe(true);
+
+    // Verify deletion
+    const checkRes = await app.request(`/clients/${createdClientId}`);
+    expect(checkRes.status).toBe(404);
+  });
+});

--- a/src/tests/serenade-bookings.router.test.ts
+++ b/src/tests/serenade-bookings.router.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import app from "../app";
+import { db, dbSchema } from "../db";
+import { serenadeBookings, clients, events } from "../db/schema";
+import type { ApiResponse } from "../types/common";
+import type {
+  SerenadeBooking,
+  SerenadeBookingsGetResponse,
+} from "../types/serenade-booking";
+import { createTestUser, loginTestUser, seedTestMember } from "../utils/test";
+import type { Member } from "../types/member";
+
+describe("Serenade Bookings Router", () => {
+  let token: string;
+  let member: Member;
+
+  // Clean up database before and after tests
+  const cleanup = async () => {
+    await db.delete(serenadeBookings);
+    await db.delete(clients);
+    await db.delete(events);
+    await db.delete(dbSchema.users);
+    await db.delete(dbSchema.members);
+  };
+
+  beforeAll(async () => {
+    await cleanup();
+    member = await seedTestMember();
+    await createTestUser({ email: "admin@email.com" }, member.vinculationCode);
+    const response = await loginTestUser("admin@email.com", "password");
+    if ("token" in response.data) {
+      token = response.data.token;
+    } else {
+      throw new Error("Failed to login test user");
+    }
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  let createdSerenadeBookingId: string;
+  let clientId: string;
+  let eventId: string;
+
+  it("POST /serenade-bookings - should create a new serenade booking", async () => {
+    // Create client and event dependencies
+    const clientRes = await db
+      .insert(clients)
+      .values({
+        name: "Test Client",
+        phone: "1234567890",
+        email: "test@client.com",
+      })
+      .returning();
+
+    if (!clientRes[0]) throw new Error("Failed to create test client");
+    clientId = clientRes[0].id;
+
+    const eventRes = await db
+      .insert(events)
+      .values({
+        name: "Test Event",
+        date: new Date().toISOString(),
+        location: "Test Location",
+        type: "serenata",
+      })
+      .returning();
+
+    if (!eventRes[0]) throw new Error("Failed to create test event");
+    eventId = eventRes[0].id;
+
+    const newBooking = {
+      eventId: eventId,
+      clientId: clientId,
+      price: 150000,
+      transportationCost: 50000,
+      occasion: "cumpleanos",
+      occasionDetails: "25th Birthday",
+      specialRequests: "Play Happy Birthday",
+    };
+
+    const res = await app.request("/serenade-bookings", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(newBooking),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as ApiResponse<SerenadeBooking>;
+    expect(body.success).toBe(true);
+    expect(body.data).toHaveProperty("id");
+    if (body.data) {
+      expect(body.data.price).toBe(newBooking.price);
+      createdSerenadeBookingId = body.data.id;
+    }
+  });
+
+  it("GET /serenade-bookings - should return a list of serenade bookings", async () => {
+    const res = await app.request("/serenade-bookings", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<SerenadeBookingsGetResponse>;
+    expect(body.success).toBe(true);
+    if (body.data) {
+      expect(Array.isArray(body.data.items)).toBe(true);
+      expect(body.data.count).toBeGreaterThan(0);
+    }
+  });
+
+  it("GET /serenade-bookings/:id - should return a specific serenade booking", async () => {
+    const res = await app.request(
+      `/serenade-bookings/${createdSerenadeBookingId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<SerenadeBooking>;
+    expect(body.success).toBe(true);
+    if (body.data) {
+      expect(body.data.id).toBe(createdSerenadeBookingId);
+    }
+  });
+
+  it("PATCH /serenade-bookings/:id - should update serenade booking details", async () => {
+    const updateData = {
+      price: 200000,
+      occasionDetails: "Updated details",
+    };
+
+    const res = await app.request(
+      `/serenade-bookings/${createdSerenadeBookingId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(updateData),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<SerenadeBooking>;
+    expect(body.success).toBe(true);
+    if (body.data) {
+      expect(body.data.price).toBe(updateData.price);
+      expect(body.data.occasionDetails).toBe(updateData.occasionDetails);
+    }
+  });
+
+  it("DELETE /serenade-bookings/:id - should delete a serenade booking", async () => {
+    const res = await app.request(
+      `/serenade-bookings/${createdSerenadeBookingId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<SerenadeBooking>;
+    expect(body.success).toBe(true);
+
+    // Verify deletion
+    const checkRes = await app.request(
+      `/serenade-bookings/${createdSerenadeBookingId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    expect(checkRes.status).toBe(404);
+  });
+});

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,0 +1,10 @@
+import { dbSchema } from "../db";
+
+export type Client = typeof dbSchema.clients.$inferSelect;
+
+export type ClientInsert = typeof dbSchema.clients.$inferInsert;
+
+export type ClientsGetResponse = {
+  items: Client[];
+  count: number;
+};

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -11,3 +11,9 @@ export type ListResponse<T> = {
   pageSize?: number;
   totalPages?: number;
 };
+
+export type ApiResponse<T> = {
+  success: boolean;
+  data?: T;
+  error?: string;
+};

--- a/src/types/serenade-booking.ts
+++ b/src/types/serenade-booking.ts
@@ -1,0 +1,15 @@
+import { dbSchema } from "../db";
+
+export type SerenadeBooking = typeof dbSchema.serenadeBookings.$inferSelect;
+
+export type SerenadeBookingInsert =
+  typeof dbSchema.serenadeBookings.$inferInsert;
+
+export type SerenadeBookingUpdate = Partial<
+  Omit<SerenadeBookingInsert, "id" | "createdAt" | "updatedAt">
+>;
+
+export type SerenadeBookingsGetResponse = {
+  items: SerenadeBooking[];
+  count: number;
+};


### PR DESCRIPTION
# Implement Clients & Serenade Bookings

This PR implements full CRUD functionality for **Clients** and **Serenade Bookings**

## Changes

### 1. Clients Module
- **Endpoints**: Full implementation of `GET`, `POST`, `PATCH`, `DELETE` for `/clients`.
- **Schemas**: Definition of robust Zod schemas (`clientInsertSchema`, `clientUpdateSchema`).
    - *Fix*: Resolved a type compatibility issue with `drizzle-zod` by using a manual definition for the client insert schema.
- **Tests**: Added integration tests with full authentication, ensuring coverage for all operations.

### 2. Serenade Bookings Module
- **Endpoints**: New resource `/serenade-bookings` with complete CRUD operations.
- **Validation**: Strict validation of IDs, and relationships with clients and events.
- **Integration**: Full flow tested from dependency creation (Client/Event) to serenade booking.